### PR TITLE
Set liveness and readinessProbe path to /health

### DIFF
--- a/charts/sandbox-metadata/templates/deployment.yaml
+++ b/charts/sandbox-metadata/templates/deployment.yaml
@@ -25,9 +25,9 @@ spec:
               protocol: TCP
           livenessProbe:
             httpGet:
-              path: /
+              path: /health
               port: http
           readinessProbe:
             httpGet:
-              path: /
+              path: /health
               port: http

--- a/charts/sandbox-notification/templates/deployment.yaml
+++ b/charts/sandbox-notification/templates/deployment.yaml
@@ -25,9 +25,9 @@ spec:
               protocol: TCP
           livenessProbe:
             httpGet:
-              path: /
+              path: /health
               port: http
           readinessProbe:
             httpGet:
-              path: /
+              path: /health
               port: http

--- a/charts/sandbox-request/templates/deployment.yaml
+++ b/charts/sandbox-request/templates/deployment.yaml
@@ -25,9 +25,9 @@ spec:
               protocol: TCP
           livenessProbe:
             httpGet:
-              path: /
+              path: /health
               port: http
           readinessProbe:
             httpGet:
-              path: /
+              path: /health
               port: http

--- a/charts/sandbox-storage/templates/deployment.yaml
+++ b/charts/sandbox-storage/templates/deployment.yaml
@@ -25,9 +25,9 @@ spec:
               protocol: TCP
           livenessProbe:
             httpGet:
-              path: /
+              path: /health
               port: http
           readinessProbe:
             httpGet:
-              path: /
+              path: /health
               port: http

--- a/charts/sandbox-ui/templates/deployment.yaml
+++ b/charts/sandbox-ui/templates/deployment.yaml
@@ -25,9 +25,9 @@ spec:
               protocol: TCP
           livenessProbe:
             httpGet:
-              path: /
+              path: /health
               port: http
           readinessProbe:
             httpGet:
-              path: /
+              path: /health
               port: http


### PR DESCRIPTION
- Services were not able to start, due to errors in FastAPI binding.
- Furthermore the liveness and readiness probe paths were set to `/`, resulting in a plain text "Hello World" response, this was replaced by the `/health` endpoint that sends a JSON message:
```
{'status': 'OK'}
```