### PR TITLE
Inject credentials from secret as env variables

### DIFF
--- a/sandbox-notification/templates/config.yaml
+++ b/sandbox-notification/templates/config.yaml
@@ -13,8 +13,3 @@ data:
     topic_name: send_notification
     max_attempts: 5
     log_level: info
-
-    # Warning, these secrets are better specified
-    # via environment variables or file secrets:
-    smtp_username: your-username-here
-    smtp_password: your-password-here

--- a/sandbox-notification/templates/deployment.yaml
+++ b/sandbox-notification/templates/deployment.yaml
@@ -21,6 +21,17 @@ spec:
       containers:
       - name: {{ .Chart.Name }}
         image: ghga/{{ .Chart.Name }}:{{ .Chart.AppVersion }}
+        env:
+        - name: SANDBOX_NOTIFICATION_SMTP_USERNAME
+          valueFrom:
+            secretKeyRef:
+              name: sandbox-notification-smtp-credentials
+              key: smtp_username
+        - name: SANDBOX_NOTIFICATION_SMTP_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: sandbox-notification-smtp-credentials
+              key: smtp_password
         ports:
         - name: http
           containerPort: 8080
@@ -33,3 +44,4 @@ spec:
       - name: config
         configMap:
           name: {{ .Chart.Name }}
+sandbox-notification-smtp-credentials


### PR DESCRIPTION
## What?
We'd to inject the smtp credentials into the sandbox-notification from a existing kubernetes secret object.

## Why?
We don't want to write the secrets as clear text in the config yaml file.

## How?
We manually created a kubernetes secret object `sandbox-notification-smtp-credentials` including base64 encoded strings of username and password.  
This service object can then be referenced in the env section of the `deployment.yaml`